### PR TITLE
Updated bazel version to fix compatibility issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export DISTDIR=/local-scratch/nigam/distdir
 Run the following:
 
 ```
-conda create -n PITON_ENV python=3.10 bazel=5 clangxx=14 -c conda-forge
+conda create -n PITON_ENV python=3.10 bazel=5.3 clangxx=14 -c conda-forge
 conda activate PITON_ENV
 git clone https://github.com/som-shahlab/piton.git
 cd piton


### PR DESCRIPTION
Installing piton was raising some issue with the version of bazel installed not being compatible with java. I changed the version of bazel in our conda environment create command to 5.3 and fixed the issue.