### PR TITLE
Preserve OMOP table naming in ETL

### DIFF
--- a/src/piton/etl_pipelines/stanford.py
+++ b/src/piton/etl_pipelines/stanford.py
@@ -23,7 +23,7 @@ from piton.transforms.stanford import (
 
 
 def _is_visit_event(e: Event) -> bool:
-    return e.omop_table == "visit"
+    return e.omop_table == "visit_occurrence"
 
 
 def _get_stanford_transformations() -> Sequence[

--- a/src/piton/extractors/omop.py
+++ b/src/piton/extractors/omop.py
@@ -163,7 +163,7 @@ class _ConceptTableConverter(CSVExtractor):
             unit = None
 
         metadata: Dict[str, Any] = {
-            "omop_table": self.prefix,
+            "omop_table": self.get_file_prefix(),
             "clarity_table": row["load_table_id"],
         }
 

--- a/src/piton/transforms/stanford.py
+++ b/src/piton/transforms/stanford.py
@@ -27,7 +27,7 @@ def move_visit_start_to_day_start(patient: Patient) -> Patient:
             event.start.hour == 0
             and event.start.minute == 0
             and event.start.second == 0
-            and event.omop_table == "visit"
+            and event.omop_table == "visit_occurrence"
         ):
             event.start = event.start + datetime.timedelta(minutes=1)
 
@@ -64,7 +64,7 @@ def move_visit_start_to_first_event_start(patient: Patient) -> Patient:
 
     # Find the stated start time for each visit
     for event in patient.events:
-        if event.omop_table == "visit":
+        if event.omop_table == "visit_occurrence":
             if event.visit_id in visit_starts:
                 raise RuntimeError(
                     f"Multiple visit events with visit ID {event.visit_id} for patient ID {patient.patient_id}"
@@ -87,7 +87,7 @@ def move_visit_start_to_first_event_start(patient: Patient) -> Patient:
 
     # Assign visit start times to be same as first non-visit event with same visit ID
     for event in patient.events:
-        if event.omop_table == "visit":
+        if event.omop_table == "visit_occurrence":
             # Triggers if there is a non-visit event associated with the visit ID that has
             # start time strictly after the recorded visit start
             if event.visit_id in first_event_starts:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -67,7 +67,7 @@ def test_move_visit_start_to_day_start() -> None:
             piton.Event(
                 start=datetime.datetime(1999, 7, 2),
                 code=1234,
-                omop_table="visit",
+                omop_table="visit_occurrence",
             ),
             piton.Event(start=datetime.datetime(1999, 7, 2, 12), code=4321),
             piton.Event(start=datetime.datetime(1999, 7, 9), code=OMOP_BIRTH),
@@ -80,7 +80,7 @@ def test_move_visit_start_to_day_start() -> None:
             piton.Event(
                 start=datetime.datetime(1999, 7, 2, 0, 1),
                 code=1234,
-                omop_table="visit",
+                omop_table="visit_occurrence",
             ),
             piton.Event(start=datetime.datetime(1999, 7, 2, 12), code=4321),
             piton.Event(start=datetime.datetime(1999, 7, 9), code=OMOP_BIRTH),
@@ -100,7 +100,7 @@ def test_move_visit_start_ignores_other_visits() -> None:
             piton.Event(  # A visit event with just date specified
                 start=datetime.datetime(1999, 7, 2),
                 code=4567,
-                omop_table="visit",
+                omop_table="visit_occurrence",
                 visit_id=9999,
             ),
             piton.Event(  # A non-visit event from a separate visit ID
@@ -137,7 +137,7 @@ def test_move_visit_start_ignores_other_visits() -> None:
             piton.Event(  # Now visit event has date and time specified
                 start=datetime.datetime(1999, 7, 2, 12),
                 code=4567,  # Comes after previous event b/c 4567 > 3456
-                omop_table="visit",
+                omop_table="visit_occurrence",
                 visit_id=9999,
             ),
         ],
@@ -167,7 +167,7 @@ def test_move_visit_start_minute_after_midnight() -> None:
                 start=datetime.datetime(1999, 7, 2),
                 code=3456,
                 visit_id=9999,
-                omop_table="visit",
+                omop_table="visit_occurrence",
             ),
         ],
     )
@@ -187,7 +187,7 @@ def test_move_visit_start_minute_after_midnight() -> None:
                 start=datetime.datetime(1999, 7, 2, 0, 1),
                 code=3456,
                 visit_id=9999,
-                omop_table="visit",
+                omop_table="visit_occurrence",
             ),
             piton.Event(
                 start=datetime.datetime(1999, 7, 2, 12),
@@ -211,7 +211,7 @@ def test_move_visit_start_doesnt_move_without_event() -> None:
                 start=datetime.datetime(1999, 7, 2),
                 code=3456,
                 visit_id=9999,
-                omop_table="visit",
+                omop_table="visit_occurrence",
             ),
             piton.Event(
                 start=datetime.datetime(1999, 7, 2, 0, 0),
@@ -238,7 +238,7 @@ def test_move_visit_start_doesnt_move_without_event() -> None:
                 start=datetime.datetime(1999, 7, 2),
                 code=3456,
                 visit_id=9999,
-                omop_table="visit",
+                omop_table="visit_occurrence",
             ),
         ],
     )


### PR DESCRIPTION
Literally just changes the `event.omop_table` extraction value to preserve the original OMOP table name (i.e. `visit_occurrence` instead of being mapped to `visit`, `condition_occurrence` instead of `condition`, and `procedure_occurrence` instead of `procedure`)